### PR TITLE
Fix for correct decimal separator for European regional settings for numeric types.

### DIFF
--- a/BilibiliSubtitle2SRT/Form1.cs
+++ b/BilibiliSubtitle2SRT/Form1.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace BilibiliSubtitle2SRT
@@ -89,8 +85,7 @@ namespace BilibiliSubtitle2SRT
 
         private string SecondToTime(string s)
         {
-            s = s.Replace(".", ","); //change decimal separator for windows regional settings  
-            TimeSpan t = TimeSpan.FromSeconds(Convert.ToDouble(s));
+            TimeSpan t = TimeSpan.FromSeconds(Convert.ToDouble(s, NumberFormatInfo.InvariantInfo));
             string result = string.Format("{0:D2}:{1:D2}:{2:D2},{3:D3}",
                                     t.Hours,
                                     t.Minutes,

--- a/BilibiliSubtitle2SRT/Form1.cs
+++ b/BilibiliSubtitle2SRT/Form1.cs
@@ -89,6 +89,7 @@ namespace BilibiliSubtitle2SRT
 
         private string SecondToTime(string s)
         {
+            s = s.Replace(".", ","); //change decimal separator for windows regional settings  
             TimeSpan t = TimeSpan.FromSeconds(Convert.ToDouble(s));
             string result = string.Format("{0:D2}:{1:D2}:{2:D2},{3:D3}",
                                     t.Hours,


### PR DESCRIPTION
Windows regional settings affect how the string is converted to decimal. In order to fix this, it is enough to add NumberFormatInfo.InvariantInfo in Convert.ToDouble function.